### PR TITLE
えらい画面作成・やること登録ページのリンクhover時に指にする

### DIFF
--- a/app/assets/stylesheets/components/c-button.scss.erb
+++ b/app/assets/stylesheets/components/c-button.scss.erb
@@ -37,3 +37,17 @@
         }
     }
 }
+
+.c-button_icon {
+    display: inline-block;
+    margin-right: 4px;
+    &:before {
+        content: '';
+        width: 16px;
+        display: block;
+        height: 16px;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-image: url("<%= asset_path('icon/icon-twitter.svg') %>")
+    }
+}

--- a/app/assets/stylesheets/components/c-weekly-stamp.scss
+++ b/app/assets/stylesheets/components/c-weekly-stamp.scss
@@ -1,0 +1,26 @@
+.weeklyStampList {
+    padding: 0;
+    text-align: center;
+    .weeklyStampList_item {
+        width: 52px;
+        height: 52px;
+        border: solid 6px #BFBFBF;
+        border-radius: 50%;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 18px;
+        color: #BFBFBF;
+        margin-right: 19px;
+        &:nth-child(4n) {
+            margin-right: 0;
+        }
+        &:nth-child(5n) {
+            margin-left: 38px;
+        }
+    }
+}
+
+.shareAction {
+    margin-top: 24px;
+}

--- a/app/assets/stylesheets/components/term.scss
+++ b/app/assets/stylesheets/components/term.scss
@@ -1,0 +1,3 @@
+.term {
+    font-size: 12px;
+}

--- a/app/assets/stylesheets/layout/layout.scss
+++ b/app/assets/stylesheets/layout/layout.scss
@@ -27,4 +27,8 @@
   &.content-howto {
     margin-top: 90px;
   }
+  .content_lead {
+    font-size: 14px;
+    margin-top: 24px;
+  }
 }

--- a/app/assets/stylesheets/pages/events.scss
+++ b/app/assets/stylesheets/pages/events.scss
@@ -1,0 +1,21 @@
+.eventsImage {
+    max-width: 174px;
+    margin: 0 auto;
+}
+
+.eventsGoalEntryImage {
+    margin-right: 12px;
+}
+
+.eventsGoalEntryText {
+    font-size: 12px;
+}
+
+.userName {
+    font-weight: 700;
+}
+
+.goalName {
+    font-weight: 700;
+    color: #F241B6;
+}

--- a/app/assets/stylesheets/pages/goal.scss
+++ b/app/assets/stylesheets/pages/goal.scss
@@ -40,4 +40,5 @@
     background: transparent;
     border-bottom: solid 1px #333;
     padding: 0;
+    cursor: pointer;
 }

--- a/app/assets/stylesheets/pages/goal.scss
+++ b/app/assets/stylesheets/pages/goal.scss
@@ -42,3 +42,7 @@
     padding: 0;
     cursor: pointer;
 }
+
+.goalShowHeading {
+    margin-top: 16px;
+}

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,8 +1,54 @@
-えらい！ <br>
-明日もシュウカンを続けましょう！
-
-<div class="eventsIntro_image">
-  <%= image_tag 'events/img-events.png' %>
+<div class="l-inner">
+  <div class="content">
+    <div class="content_inner">
+      <div class="content_header">
+        <h2 class="c-headingLv2">おつかれさまでした！</h2>
+        <p class="content_lead">えらい！<br>明日もシュウカンを続けましょう！</p>
+      </div>
+      <div class="content_body">
+        <div class="eventsImage">
+          <%= image_tag 'events/img-events.png' %>
+        </div>
+        <div class="weeklyStamp">
+          <ul class="weeklyStampList">
+            <li class="weeklyStampList_item">mon</li>
+            <li class="weeklyStampList_item">tue</li>
+            <li class="weeklyStampList_item">wed</li>
+            <li class="weeklyStampList_item">thu</li>
+            <li class="weeklyStampList_item">fir</li>
+            <li class="weeklyStampList_item">sat</li>
+            <li class="weeklyStampList_item">sun</li>
+          </ul>
+        </div>
+        <div class="shareAction">
+          <!--リンクをここに-->
+          <!--<a href="https://twitter.com/share?url=【URL】&text=【テキスト】</a>-->
+          <button class="c-button c-button-twitter"><i class="c-button_icon"></i>Twitterでシェア</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="content">
+    <div class="content_inner">
+      <div class="content_header">
+        <h2 class="c-headingLv2">他の人のシュウカンを見る</h2>
+      </div>
+      <div class="content_body">
+        <% date = nil %>
+        <div class="eventsGoalEntryImage">
+          <img src="https://picsum.photos/96/96" />
+        </div>
+        <p class="eventsGoalEntryText">
+          <% @events.each do |event| %>
+            <span class="userName"><%= event.goal.user.name %></span>
+            さんが、
+            <span class="goalName"><%= event.goal.name %>(<%= event.goal.category.name %>)</span>
+            を達成しました！
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
 </div>
 
 <hr />

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -2,7 +2,11 @@
     <div class="content">
         <div class="content_inner">
             <div class="content_header">
-                <h2 class="c-headingLv2"><%= @goal.name %>（<%= @goal.category.name %>）</h2>
+                <% from = Date.current.beginning_of_week; to =  from + 6.day %>
+                <p class="term"><%= from.strftime('%Y.%m.%d') %>〜<%= to.strftime('%Y.%m.%d') %>のシュウカン</p>
+                <div class="goalShowHeading">
+                    <h2 class="c-headingLv2"><%= @goal.name %></h2>
+                </div>
             </div>
             <div class="content_body">
                 <div class="goalShowImage">


### PR DESCRIPTION
## 概要
- やること登録ページの継続リンクhover時に指にする

![image](https://user-images.githubusercontent.com/12878889/121793832-d3000f80-cc3d-11eb-9cc2-8e75e84b805e.png)

- えらい画面コーディング

<img width="350" alt="スクリーンショット 2021-06-13 11 52 48" src="https://user-images.githubusercontent.com/12878889/121793837-e9a66680-cc3d-11eb-8b10-f01452d701ca.png">
<img width="359" alt="スクリーンショット 2021-06-13 11 52 55" src="https://user-images.githubusercontent.com/12878889/121793840-ef9c4780-cc3d-11eb-8ff3-2018b9eae561.png">
